### PR TITLE
tsa trust_remote_code=True

### DIFF
--- a/evaluation_scripts/tsa_finetuning.py
+++ b/evaluation_scripts/tsa_finetuning.py
@@ -187,6 +187,7 @@ config = AutoConfig.from_pretrained(
     cache_dir=model_args.cache_dir,
     revision=model_args.model_revision,
     use_auth_token=True if model_args.use_auth_token else None,
+    trust_remote_code=True,
 )
 tokenizer_name_or_path = model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path
 if config.model_type in {"gpt2", "roberta"}:


### PR DESCRIPTION
trust_remote_code=True seems to be needed now,  for the config = AutoConfig.from_pretrained.   
Hard-coding this seems not to be too dangerous.